### PR TITLE
Add path separator to end of Dir.tmpdir when generating tempfile name

### DIFF
--- a/lib/hoppler.rb
+++ b/lib/hoppler.rb
@@ -21,7 +21,7 @@ class Hoppler
     databases.each do |database|
       begin
         # Dump to tempfile
-        tmpfile = Dir::Tmpname.make_tmpname Dir.tmpdir, nil    
+        tmpfile = Dir::Tmpname.make_tmpname Dir.tmpdir+File::Separator, nil
         dump_cmd = "mysqldump #{database} -u #{ENV['MYSQL_USERNAME']} --single-transaction"
         dump_cmd << " --password=#{ENV['MYSQL_PASSWORD']}" if ENV['MYSQL_PASSWORD']
         system "#{dump_cmd} | bzip2 > #{tmpfile}"


### PR DESCRIPTION
Resolves #3
