### PR TITLE
Add parameter to restore function

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,12 +1,19 @@
 require './lib/hoppler.rb'
 
-namespace :hoppler do
+namespace :hoppler do 
+  task :environment do
+  end
+  
   task :backup do
     Hoppler.backup
   end
   
-  task :restore do
-    Hoppler.restore
+  task :restore, [:hostname] => :environment do |t, args|
+    if args[:hostname].nil?
+      Hoppler.restore
+    else
+      Hoppler.restore(args[:hostname])
+    end
   end
   
   task :cleanup do

--- a/features/restore.feature
+++ b/features/restore.feature
@@ -14,3 +14,12 @@ Feature: Restore databases from backup
     And I should have a database called "db_2"
     And "db_1" should contain the correct stuff
     And "db_2" should contain the correct stuff
+  
+  Scenario: Restore databases from a specific node
+    Given there is a database backup called "derp-the-odi-org/db_1/2013-05-28.sql.bz2" in Rackspace
+    And there is a database backup called "derp-the-odi-org/db_2/2013-05-28.sql.bz2" in Rackspace
+    When I run the restore command for "derp-the-odi-org"
+    Then I should have a database called "db_1"
+    And I should have a database called "db_2"
+    And "db_1" should contain the correct stuff
+    And "db_2" should contain the correct stuff

--- a/features/step_definitions/hoppler_steps.rb
+++ b/features/step_definitions/hoppler_steps.rb
@@ -81,6 +81,10 @@ When(/^I run the restore command$/) do
   `rake hoppler:restore`
 end
 
+When(/^I run the restore command for "(.*?)"$/) do |hostname|
+  `rake hoppler:restore['#{hostname}']`
+end
+
 Then(/^I should have a database called "(.*?)"$/) do |db|
   mysql.query("SHOW DATABASES LIKE '#{db}'").count.should == 1
 end

--- a/features/step_definitions/hoppler_steps.rb
+++ b/features/step_definitions/hoppler_steps.rb
@@ -8,6 +8,14 @@ Given(/^I have a database called "(.*?)"$/) do |db|
   system command
 end
 
+Given(/^there is a database backup called "(.*?)\/(.*?)\/(.*?).sql.bz2" in Rackspace$/) do |hostname, db, date|
+  tmpfile = Dir::Tmpname.make_tmpname Dir.tmpdir+File::Separator, nil
+  system "cat ./features/fixtures/#{db}.sql | bzip2 > #{tmpfile}"
+  dir = Hoppler.rackspace.directories.get ENV['RACKSPACE_DB_CONTAINER']
+  filename = "#{hostname}/#{db}/#{filename}.sql.bz2"
+  dir.files.create :key => filename, :body => File.open(tmpfile)
+end
+
 When(/^I run the backup command$/) do
   Hoppler.backup
 end
@@ -36,7 +44,7 @@ Given(/^it's two months in the future$/) do
 end
 
 When(/^I run the cleanup command$/) do
-  Hoppler.cleanup
+  `rake hoppler:cleanup`
 end
 
 Then(/^I should not have a database backup called "(.*?)"$/) do |file|
@@ -70,7 +78,7 @@ Then(/^"(.*?)" should contain the correct stuff$/) do |db|
 end
 
 When(/^I run the restore command$/) do
-  Hoppler.restore
+  `rake hoppler:restore`
 end
 
 Then(/^I should have a database called "(.*?)"$/) do |db|

--- a/lib/hoppler.rb
+++ b/lib/hoppler.rb
@@ -59,12 +59,12 @@ class Hoppler
     end
   end
 
-  def self.restore
+  def self.restore(hostname = self.hostname)
     dumps = {}
     dir = self.rackspace.directories.get ENV['RACKSPACE_DB_CONTAINER']
     dir.files.each do |f|
       c = Cloudfile.new f
-      if c.host == self.hostname
+      if c.host == hostname
         if dumps[c.db]
           if c.key > dumps[c.db].key
             dumps[c.db] = c


### PR DESCRIPTION
We can now specify the name of the node to restore from if we want, so now we can restore from the backup of an existing node with a different name. Fixes #8
